### PR TITLE
Add initialization options

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ ReactDOM.render(
       csrf={'csrf token here!'} // Required for security
       countryCode={'default country code'} // eg. +60
       phoneNumber={'default phone number'} // eg. 12345678
-      emailAddress={'default email address'} // eg. me@site.com 
+      emailAddress={'default email address'} // eg. me@site.com
     >
       {p => <button {...p}>Initialize Account Kit</button>}
     </AccountKit>,
@@ -39,12 +39,16 @@ ReactDOM.render(
 
 ## Optional Props
 - ```loginType``` default is ```PHONE```
+- ```debug``` default is ```false```
 - ```disabled``` default is ```false```
+- ```display``` default is ```popup```
 - ```language``` default is ```en_US```
 - ```countryCode``` default country code. default value is ```undefined```
 - ```phoneNumber``` default phone number. default value is ```undefined```
-- ```emailAddress``` default email address. default value is ```undefined```
-*`loginType`* must be set to ```"EMAIL"``` for this to work. 
+- ```emailAddress``` default email address. default value is ```undefined```.
+*`loginType`* must be set to ```"EMAIL"``` for this to work.
+- ```redirect``` redirect URL after email confirmation. default value is ```undefined```.
+*`loginType`* must be set to ```"EMAIL"``` for this to work.
 
 
 ## Dev Server

--- a/src/index.js
+++ b/src/index.js
@@ -29,11 +29,14 @@ class AccountKit extends React.Component {
   }
 
   onLoad() {
-    const { appId, csrf, version } = this.props;
+    const { appId, csrf, version, debug, display, redirect } = this.props;
     window.AccountKit.init({
       appId,
       state: csrf,
       version,
+      debug,
+      display,
+      redirect,
       fbAppEventsEnabled: false
     });
     this.setState({
@@ -85,7 +88,10 @@ AccountKit.propTypes = {
   children: PropTypes.func.isRequired,
   onResponse: PropTypes.func.isRequired,
   loginType: PropTypes.oneOf(["PHONE", "EMAIL"]),
+  debug: PropTypes.bool,
   disabled: PropTypes.bool,
+  display: PropTypes.oneOf(["popup", "modal"]),
+  redirect: PropTypes.string,
   language: PropTypes.string,
   countryCode: PropTypes.string,
   phoneNumber: PropTypes.string,
@@ -93,7 +99,9 @@ AccountKit.propTypes = {
 };
 
 AccountKit.defaultProps = {
+  debug: false,
   disabled: false,
+  display: "popup",
   language: "en_US",
   loginType: "PHONE"
 };


### PR DESCRIPTION
Added some initialization options. From the [documentation](https://developers.facebook.com/docs/accountkit/webjs/reference/):

- **debug**: A Boolean specifying whether to display a descriptive error message when an error occurs. If true, an explicit error message is displayed. If false, only a generic error is displayed.
- **display**: For SMS login only. A string containing a value that determines the login display. The two values are popup and modal. The default value is popup. If display is set to modal, Account Kit login will display in iframe.
- **redirect**: A string containing the URL to which people will be redirected after email confirmation. This is for email only and is optional. Note that this URL must match the URL saved in the Account Kit app settings.

Maybe it'll be necessary to update the version number in package.json so that npm shows the changes.